### PR TITLE
Restore past feature of requring unlock state for decryption

### DIFF
--- a/app/src/main/java/com/stevesoltys/seedvault/crypto/KeyManager.kt
+++ b/app/src/main/java/com/stevesoltys/seedvault/crypto/KeyManager.kt
@@ -100,9 +100,7 @@ internal class KeyManagerImpl(
             .setEncryptionPaddings(ENCRYPTION_PADDING_NONE)
             .setRandomizedEncryptionRequired(true)
         // unlocking is required only for decryption, so when restoring from backup
-        // FIXME disabled for Android 12 GSI as it crashes when importing the key
-        //  KeyStoreException: Failed to import secret key.
-        // builder.setUnlockedDeviceRequired(true)
+        builder.setUnlockedDeviceRequired(true)
         return builder.build()
     }
 


### PR DESCRIPTION
GrapheneOS don't support GSI, thus the compat change is unnecessary.