### PR TITLE
add POST_NOTIFICATIONS to AndroidManifest

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -54,6 +54,7 @@
 
     <!-- Used to authenticate saving a new recovery code -->
     <uses-permission android:name="android.permission.USE_BIOMETRIC" />
+    <uses-permission android:name="android.permission.POST_NOTIFICATIONS" />
 
     <!-- Permission used to open settings -->
     <permission


### PR DESCRIPTION
Needed for sending notifications when targetSdk is 33 (default when building with AOSP 13).

Depends on https://github.com/GrapheneOS/platform_frameworks_base/pull/254