### PR TITLE
allow new content provider for DAVx⁵ WebDAV provider

### DIFF
--- a/app/src/main/res/values/config.xml
+++ b/app/src/main/res/values/config.xml
@@ -11,6 +11,7 @@
     <string-array name="storage_authority_backup_allow_list">
         <item>com.android.externalstorage.documents</item>
         <item>at.bitfire.davdroid.webdav</item>
+        <item>at.bitfire.davdroid.provider.webdav</item>
         <item>de.felixnuesse.extract.vcp</item>
     </string-array>
 
@@ -23,6 +24,7 @@
         <item>com.android.externalstorage.documents</item>
         <item>org.nextcloud.documents</item>
         <item>at.bitfire.davdroid.webdav</item>
+        <item>at.bitfire.davdroid.provider.webdav</item>
         <item>de.felixnuesse.extract.vcp</item>
     </string-array>
 


### PR DESCRIPTION
Closes https://github.com/GrapheneOS/os-issue-tracker/issues/7810

https://github.com/bitfireAT/davx5-ose/pull/2201

> A change to the authority names is necessary because of a Google Play bug that currently prevents
> us from submitting updates for the app

Test: Using the APK from https://github.com/bitfireAT/davx5-ose/releases/tag/v4.5.12-ose, WebDAV mounts that are setup in DAVx⁵ show up in Seedvault now. Prior to this fix, those individual mounts weren't visible.

Test: Backup and restore with WebDAV server with DAVx⁵ v4.5.12-ose succeeded